### PR TITLE
cheri: Do not use ".dont_seal" directives for trap handlers.

### DIFF
--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -493,12 +493,12 @@ _start_warm:
 #endif
 
 	/* Setup trap handler */
-	PTR_L	PREG(a4), _trap_handler
+	PC_PTR_L	PREG(a4), _trap_handler
 	csrr	a5, CSR_MISA
 	srli	a5, a5, ('H' - 'A')
 	andi	a5, a5, 0x1
 	beq	a5, zero, _skip_trap_handler_hyp
-	PTR_L	PREG(a4), _trap_handler_hyp
+	PC_PTR_L	PREG(a4), _trap_handler_hyp
 _skip_trap_handler_hyp:
 	csrw	CSR_MTVEC, PREG(a4)
 
@@ -799,9 +799,6 @@ memcmp:
 	.align 3
 	.globl _trap_handler
 	.type  _trap_handler, @function
-#if defined(__CHERI_PURE_CAPABILITY__)
-	.dont_seal _trap_handler
-#endif
 _trap_handler:
 	TRAP_SAVE_AND_SETUP_SP_T0
 
@@ -826,9 +823,6 @@ _trap_handler:
 	.align 3
 	.globl _trap_handler_hyp
 	.type  _trap_handler_hyp, @function
-#if defined(__CHERI_PURE_CAPABILITY__)
-	.dont_seal _trap_handler
-#endif
 _trap_handler_hyp:
 	TRAP_SAVE_AND_SETUP_SP_T0
 

--- a/include/sbi/sbi_hart.h
+++ b/include/sbi/sbi_hart.h
@@ -12,6 +12,7 @@
 
 #include <sbi/sbi_types.h>
 #include <sbi/sbi_bitops.h>
+#include <sbi/riscv_cheri.h>
 
 /** Possible privileged specification versions of a hart */
 enum sbi_hart_priv_versions {
@@ -113,7 +114,12 @@ int sbi_hart_init(struct sbi_scratch *scratch, bool cold_boot);
 extern void (*sbi_hart_expected_trap)(void);
 static inline uintptr_t sbi_hart_expected_trap_addr(void)
 {
+#ifdef __CHERI_PURE_CAPABILITY__
+	return (uintptr_t)cheri_address_set(cheri_pcc_get(),
+	    cheri_address_get(sbi_hart_expected_trap));
+#else
 	return (uintptr_t)sbi_hart_expected_trap;
+#endif
 }
 
 unsigned int sbi_hart_mhpm_mask(struct sbi_scratch *scratch);

--- a/lib/sbi/sbi_expected_trap.S
+++ b/lib/sbi/sbi_expected_trap.S
@@ -22,9 +22,6 @@
 	.align 3
 	.global __sbi_expected_trap
 	.type 	__sbi_expected_trap, @function
-#if defined(__CHERI_PURE_CAPABILITY__)
-	.dont_seal __sbi_expected_trap
-#endif
 __sbi_expected_trap:
 	/* Without H-extension so, MTVAL2 and MTINST CSRs and GVA not available */
 	csrr	a4, CSR_MCAUSE
@@ -43,9 +40,6 @@ __sbi_expected_trap:
 	.align 3
 	.global __sbi_expected_trap_hext
 	.type 	__sbi_expected_trap_hext, @function
-#if defined(__CHERI_PURE_CAPABILITY__)
-	.dont_seal __sbi_expected_trap_hext
-#endif
 __sbi_expected_trap_hext:
 	/* With H-extension so, MTVAL2 and MTINST CSRs and GVA available */
 	csrr	a4, CSR_MCAUSE

--- a/lib/utils/serial/semihosting.c
+++ b/lib/utils/serial/semihosting.c
@@ -62,9 +62,6 @@ bool semihosting_enabled(void)
 		"	j _semihost_test_vector_next\n"
 		"	.align 4\n"
 		"	.type  _semihost_test_vector, @function\n"
-#if defined(__CHERI_PURE_CAPABILITY__)
-		"	.dont_seal  _semihost_test_vector\n"
-#endif
 		"_semihost_test_vector:\n"
 		"	csrr %[tmp], " STR(CSR_MEPC) "\n"
 		"	add %[tmp], %[tmp], 4\n"
@@ -74,7 +71,7 @@ bool semihosting_enabled(void)
 		"	.size _semihost_test_vector, . - _semihost_test_vector\n"
 
 		"_semihost_test_vector_next:\n"
-		"	" PTR_L " %[tmp2], _semihost_test_vector\n"
+		"	" PC_PTR_L " %[tmp2], _semihost_test_vector\n"
 		"	csrrw %[tmp2], " STR(CSR_MTVEC) ", %[tmp2]\n"
 		"	.align 4\n"
 		"	slli zero, zero, 0x1f\n"

--- a/platform/generic/thead/thead_c9xx_errata_tlb_flush.c
+++ b/platform/generic/thead/thead_c9xx_errata_tlb_flush.c
@@ -9,10 +9,15 @@
 #include <sbi/riscv_encoding.h>
 #include <sbi/riscv_asm.h>
 #include <sbi/sbi_types.h>
+#include <sbi/riscv_cheri.h>
 
 void _thead_tlb_flush_fixup_trap_handler(void);
 
 void thead_register_tlb_flush_trap_handler(void)
 {
-	ptr_csr_write(CSR_MTVEC, (uintptr_t)&_thead_tlb_flush_fixup_trap_handler);
+	uintptr_t mtvec = (uintptr_t)&_thead_tlb_flush_fixup_trap_handler;
+#if defined(__CHERI_PURE_CAPABILITY__)
+	mtvec = (uintptr_t)cheri_address_set(cheri_pcc_get(), mtvec);
+#endif
+	ptr_csr_write(CSR_MTVEC, mtvec);
 }

--- a/platform/generic/thead/thead_c9xx_tlb_trap_handler.S
+++ b/platform/generic/thead/thead_c9xx_tlb_trap_handler.S
@@ -9,9 +9,6 @@
 	.align 3
 	.globl _thead_tlb_flush_fixup_trap_handler
 	.type  _thead_tlb_flush_fixup_trap_handler, @function
-#if defined(__CHERI_PURE_CAPABILITY__)
-	.dont_seal _thead_tlb_flush_fixup_trap_handler
-#endif
 _thead_tlb_flush_fixup_trap_handler:
 	sfence.vma zero, t0
 	j _trap_handler


### PR DESCRIPTION
Instead of relying on the toolchain and relocations to understand this, derive the trap handler pointer from pcc.

This is more robust with respect to future toolchain changes, in particular with respect to relocation changes used by CheriBSD c18n implementations.
There is little reason to not use pc-relative derivation or capability re-derivation for the trap handlers.