### PR TITLE
cheri: Fix streln overflow in printcap function.

### DIFF
--- a/lib/sbi/sbi_console.c
+++ b/lib/sbi/sbi_console.c
@@ -357,6 +357,7 @@ static int printcap(char **out, u32 *out_len, uintptr_t cap,
 	*s++ = '-';
 #endif
 	*s++ = ':';
+	*s = '\0';
 	pc += prints(out, out_len, print_buf, 0, flags);
 
 	/* Print Capability Level */


### PR DESCRIPTION
The string buffer is not properly terminated before calling prints. This leads to a buffer overflow in strlen, which likely results in and exception loop.

This addresses #4 