### PR TITLE
Fix 32-bit build after 0a940983

### DIFF
--- a/lib/utils/ipi/fdt_ipi_mswi.c
+++ b/lib/utils/ipi/fdt_ipi_mswi.c
@@ -20,7 +20,7 @@ static int ipi_mswi_cold_init(void *fdt, int nodeoff,
 	int rc;
 	unsigned long offset;
 	struct aclint_mswi_data *ms;
-	uint64_t addr;
+	unsigned long addr;
 
 	ms = sbi_zalloc(sizeof(*ms));
 	if (!ms)

--- a/lib/utils/ipi/fdt_ipi_plicsw.c
+++ b/lib/utils/ipi/fdt_ipi_plicsw.c
@@ -21,7 +21,7 @@ int fdt_plicsw_cold_ipi_init(void *fdt, int nodeoff,
 				const struct fdt_match *match)
 {
 	int rc;
-	uint64_t addr;
+	unsigned long addr;
 
 	rc = fdt_parse_plicsw_node(fdt, nodeoff, &addr, &plicsw.size,
 				   &plicsw.hart_count);


### PR DESCRIPTION
Fixes: 0a940983 ("lib: utils/ipi: Use IO pointer return from ioreamp()")